### PR TITLE
Flags are comma separated

### DIFF
--- a/src/pages/accounts/index.js
+++ b/src/pages/accounts/index.js
@@ -50,7 +50,7 @@ const EditAccountModal = ({title, user, closeFunc}) => {
 			flags.push('MOD');
 		if(form.host)
 			flags.push('HOST');
-		flags = flags.join(' ');
+		flags = flags.join(',');
 
 		try {
 			if(!user.id) {


### PR DESCRIPTION
As of 2.1.15, drawpile-srv only allows comma separated flags.